### PR TITLE
Fix extra spacing

### DIFF
--- a/src/handlers/testing/exec/components/progress/index.tsx
+++ b/src/handlers/testing/exec/components/progress/index.tsx
@@ -79,7 +79,6 @@ function TestRow(props: {
         ) : (
           <Spinner type="dots" />
         )}
-        <Space />
         <Text bold={true}>{props.testExternalId}</Text>
         <Spacer />
         <Text>


### PR DESCRIPTION
I added `columnGap={1}` to this `<Box>` but forgot to remove the `<Space>` so there is extra spacing between the pass/fail icon and the name of the test

before:

<img width="1676" alt="Screenshot 2024-02-21 at 9 07 55 AM" src="https://github.com/autoblocksai/cli/assets/7498009/1632d0ce-1337-4529-923b-f69daf94ef20">

after:

<img width="1670" alt="Screenshot 2024-02-21 at 9 11 06 AM" src="https://github.com/autoblocksai/cli/assets/7498009/638c2a42-d38e-4c3d-8ba5-032925277423">
