### PR TITLE
EPD-719 prompt-snapshot-id -> prompt-snapshots

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      prompt-snapshot-id:
+      prompt-snapshots:
         type: string
-        description: The ID of the prompt snapshot that triggered this workflow
+        description: The prompt snapshot(s) that triggered this workflow
         required: false
   schedule:
     - cron: '17 15 * * *'

--- a/src/handlers/testing/exec/index.ts
+++ b/src/handlers/testing/exec/index.ts
@@ -157,7 +157,7 @@ class RunManager {
       commitCommittedDate: ciContext.commitCommittedDate,
       pullRequestNumber: ciContext.pullRequestNumber,
       pullRequestTitle: ciContext.pullRequestTitle,
-      promptSnapshotId: ciContext.promptSnapshotId,
+      promptSnapshots: ciContext.promptSnapshots,
     });
 
     this.ciBuildId = id;
@@ -607,10 +607,12 @@ export async function exec(args: {
         ...process.env,
         AUTOBLOCKS_CLI_SERVER_ADDRESS: serverAddress,
       };
-      if (ciContext?.promptSnapshotId) {
+      if (ciContext?.promptSnapshots) {
         // The prompt SDKs will use this environment variable to know that they
-        // need to pull down and use a prompt snapshot
-        commandEnv.AUTOBLOCKS_PROMPT_SNAPSHOT_ID = ciContext.promptSnapshotId;
+        // need to pull down and use prompt snapshot(s)
+        commandEnv.AUTOBLOCKS_PROMPT_SNAPSHOTS = JSON.stringify(
+          ciContext.promptSnapshots,
+        );
       }
 
       // Execute the command


### PR DESCRIPTION
decided to go w/ a map that maps the prompt's ID to its snapshot ID:

```
gh workflow run e2e.yml \
  --ref nicole/epd-719-cli-prompt-snapshot-id-prompt-snapshot-ids \
  --field prompt-snapshots='{"text-summarization":"123","text-classififer":"456"}'
```

https://github.com/autoblocksai/cli/actions/runs/8347194103/job/22846266324#step:3:229

```
 "event": {
    "inputs": {
      "prompt-snapshots": "{\"text-summarization\":\"123\",\"text-classififer\":\"456\"}"
    },
```

https://github.com/autoblocksai/cli/actions/runs/8347194103/job/22846266324#step:8:31

```
  "promptSnapshots": {
    "text-summarization": "123",
    "text-classififer": "456"
  }
```

this will be nicer for the SDKs as well because then the prompt manager will know the prompt ID beforehand and can skip trying to override w/ a snapshot if there is none for its ID. so i'll be able to drop this: https://github.com/autoblocksai/python-sdk/pull/149/files#diff-4e124f39d32018a40189c28c9452a15f042fd1c6eb54d58eeb286ed42c8b6381R149-R154


