### PR TITLE
exit 1 on http error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,3 +108,25 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AUTOBLOCKS_API_KEY: ${{ secrets.AUTOBLOCKS_API_KEY }}
+
+  notify:
+    needs:
+      - py
+      - ts
+
+    if: always() && contains(needs.*.result, 'failure') && github.event_name == 'schedule'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": ":warning:  Workflow `${{ github.workflow }}` in repository `${{ github.repository }}` failed. <${{ env.run-url }}|Logs>"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.AUTOBLOCKS_SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/src/handlers/testing/exec/util/emitter.ts
+++ b/src/handlers/testing/exec/util/emitter.ts
@@ -19,7 +19,7 @@ const zConsoleLogSchema = z.object({
 });
 
 const zUncaughtErrorSchema = z.object({
-  testExternalId: z.string(),
+  testExternalId: z.string().optional(),
   // Will be defined if the error occurred within a certain test case
   testCaseHash: z.string().optional(),
   // Will be defined if the error occurred within a certain evaluator


### PR DESCRIPTION
we were not exiting with status code 1 if there was an uncaught error in our own endpoints

also adding slack notifications if the scheduled e2e tests fail