### PR TITLE
Preserve newlines when logging stacktrace

### DIFF
--- a/src/handlers/testing/exec/util/hono-app.ts
+++ b/src/handlers/testing/exec/util/hono-app.ts
@@ -14,8 +14,8 @@ export function createHonoApp(runManager: RunManager): Hono {
     runManager.handleUncaughtError({
       error: {
         name: 'HTTPError',
-        message: `${c.req.method} ${c.req.path}: ${err.message}`,
-        stacktrace: '',
+        message: `${c.req.method} ${c.req.path}`,
+        stacktrace: err.stack ?? err.message,
       },
       ctx: 'cli',
     });


### PR DESCRIPTION
## Python
![Screenshot 2024-04-24 at 6 17 26 PM](https://github.com/autoblocksai/cli/assets/7498009/3ddeba4a-5ced-48c4-9539-88ef83b0443c)

## TS
![Screenshot 2024-04-24 at 6 08 13 PM](https://github.com/autoblocksai/cli/assets/7498009/9d7f1424-3bb6-400d-a41f-79a1e23ce9a5)
