### PR TITLE
autoblocks-prompt-snapshots -> autoblocks-overrides

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,9 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      autoblocks-prompt-snapshots:
+      autoblocks-overrides:
         type: string
-        description: The prompt snapshot(s) that triggered this workflow
+        description: Overrides for Autoblocks-managed entities
         required: false
   schedule:
     - cron: '17 15 * * *'

--- a/src/handlers/testing/exec/index.ts
+++ b/src/handlers/testing/exec/index.ts
@@ -115,7 +115,7 @@ export async function exec(args: {
       if (ciContext?.autoblocksOverrides?.promptRevisions) {
         // The prompt SDKs will use this environment variable to know that they
         // need to pull down and use prompt snapshot(s)
-        commandEnv.AUTOBLOCKS_PROMPT_SNAPSHOTS = JSON.stringify(
+        commandEnv.AUTOBLOCKS_PROMPT_REVISIONS = JSON.stringify(
           ciContext.autoblocksOverrides.promptRevisions,
         );
       }

--- a/src/handlers/testing/exec/index.ts
+++ b/src/handlers/testing/exec/index.ts
@@ -112,11 +112,11 @@ export async function exec(args: {
         ...process.env,
         AUTOBLOCKS_CLI_SERVER_ADDRESS: serverAddress,
       };
-      if (ciContext?.promptSnapshots) {
+      if (ciContext?.autoblocksOverrides?.promptRevisions) {
         // The prompt SDKs will use this environment variable to know that they
         // need to pull down and use prompt snapshot(s)
         commandEnv.AUTOBLOCKS_PROMPT_SNAPSHOTS = JSON.stringify(
-          ciContext.promptSnapshots,
+          ciContext.autoblocksOverrides.promptRevisions,
         );
       }
 

--- a/src/handlers/testing/exec/util/run-manager.ts
+++ b/src/handlers/testing/exec/util/run-manager.ts
@@ -149,7 +149,7 @@ export class RunManager {
         commitCommittedDate: ciContext.commitCommittedDate,
         pullRequestNumber: ciContext.pullRequestNumber,
         pullRequestTitle: ciContext.pullRequestTitle,
-        promptSnapshots: ciContext.promptSnapshots,
+        autoblocksOverrides: ciContext.autoblocksOverrides,
       },
     );
 


### PR DESCRIPTION
making this more generic so that we can also add config revisions

also renamed from prompt snapshots to prompt revisions