### PR TITLE
Fix commit sha on pull request events

### DIFF
--- a/src/handlers/testing/exec/util/ci.ts
+++ b/src/handlers/testing/exec/util/ci.ts
@@ -175,8 +175,8 @@ export async function makeCIContext(): Promise<CIContext> {
   const pullRequest = pullRequestFromEvent(event);
   const autoblocksOverrides = autoblocksOverridesFromEvent(event);
 
-  // The commit sha for pull request events is the last merge commit
-  // but we want the commit sha of the head commit
+  // The GITHUB_SHA env var for pull request events is the last merge commit
+  // on GITHUB_REF, but we want the commit sha of the head commit of the PR.
   const commitSha = pullRequest?.head.sha || env.GITHUB_SHA;
   const commit = await parseCommitFromGitLog(commitSha);
 


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request

<img width="745" alt="Screenshot 2024-04-26 at 1 53 31 PM" src="https://github.com/autoblocksai/cli/assets/7498009/b9620f39-3972-4b84-89f0-df42974a8319">

https://github.com/autoblocksai/cli/actions/runs/8852260463/job/24310573277?pr=53

<img width="645" alt="Screenshot 2024-04-26 at 1 54 22 PM" src="https://github.com/autoblocksai/cli/assets/7498009/c26821dc-4b54-466b-a20b-5d376943144a">
