### PR TITLE
Send dataset item id

### DIFF
--- a/src/handlers/testing/exec/util/hono-app.ts
+++ b/src/handlers/testing/exec/util/hono-app.ts
@@ -194,6 +194,7 @@ export function createHonoApp(runManager: RunManager): Hono {
           .nullish()
           .transform((x) => x ?? undefined),
         testCaseHash: z.string(),
+        datasetItemId: z.string().nullish(),
         testCaseBody: z.record(z.string(), z.unknown()),
         testCaseOutput: z.unknown(),
         testCaseDurationMs: z.number().min(0).nullish(),

--- a/src/handlers/testing/exec/util/run-manager.ts
+++ b/src/handlers/testing/exec/util/run-manager.ts
@@ -417,6 +417,7 @@ export class RunManager {
     testExternalId: string;
     runId?: string;
     testCaseHash: string;
+    datasetItemId?: string;
     testCaseBody: Record<string, unknown>;
     testCaseOutput?: unknown;
     testCaseDurationMs?: number | null;
@@ -454,6 +455,7 @@ export class RunManager {
         testCaseHash: args.testCaseHash,
         testCaseDurationMs: args.testCaseDurationMs,
         testCaseRevisionUsage: args.testCaseRevisionUsage,
+        datasetItemId: args.datasetItemId,
       },
     );
 

--- a/src/handlers/testing/exec/util/run-manager.ts
+++ b/src/handlers/testing/exec/util/run-manager.ts
@@ -417,7 +417,7 @@ export class RunManager {
     testExternalId: string;
     runId?: string;
     testCaseHash: string;
-    datasetItemId?: string;
+    datasetItemId?: string | null;
     testCaseBody: Record<string, unknown>;
     testCaseOutput?: unknown;
     testCaseDurationMs?: number | null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `datasetItemId` property to enhance data structure flexibility within the application.
	- Updated `RunManager` to support the new `datasetItemId` property during instantiation.
	- Added `datasetItemId` to the schema definition in the `createHonoApp` function for improved data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->